### PR TITLE
Update ansible callback URL

### DIFF
--- a/services/ansible/request_tower_configuration.sh
+++ b/services/ansible/request_tower_configuration.sh
@@ -13,7 +13,7 @@ retry_attempts=10
 attempt=0
 while [[ $attempt -lt $retry_attempts ]]
 do
-  status_code=`curl -s -i --data "host_config_key=$2" http://$1/api/v1/job_templates/$3/callback/ | head -n 1 | awk '{print $2}'`
+  status_code=`curl -s -i --data "host_config_key=$2" https://$1/api/v2/job_templates/$3/callback/ | head -n 1 | awk '{print $2}'`
   if [[ $status_code -ge 300 ]]
     then
     echo "${status_code} received, encountered problem, halting."


### PR DESCRIPTION
Update callback URL valid for Ansible Tower 3.2.2.

Also shouldn't this folder be called `ansible_client`? You get a `Failed executing script: tower.sh ...` error otherwise if you deploy it in CloudCenter.